### PR TITLE
PEP 8 code format

### DIFF
--- a/wafw00f/__init__.py
+++ b/wafw00f/__init__.py
@@ -49,7 +49,7 @@ currentDir = os.getcwd()
 scriptDir = os.path.dirname(sys.argv[0]) or '.'
 os.chdir(scriptDir)
 
-from wafw00f.lib.evillib import *
+from wafw00f.lib.evillib import oururlparse, scrambledheader, waftoolsengine
 
 __version__ = '0.9.2'
 


### PR DESCRIPTION
Recently, I have some new CDN check logic to add, and will change some code in wafw00f/**init**.py, so maybe I want code format this file first.

Most of these commits are PEP 8 code format, like.
- trim trailing whitespace
- single or two blank lines
- using single quote if not docstring
- print () -> print()
- add some whitespace, make code more readable
- remove repeat "import random"
- remove wildcard import
