### PR TITLE
This exception is only valid for http proxy, not socks5

### DIFF
--- a/wafw00f/lib/evillib.py
+++ b/wafw00f/lib/evillib.py
@@ -436,8 +436,6 @@ class waftoolsengine:
                 return r
 
     def _parse_proxy(self, proxy, ssl):
-        if ssl:
-            raise Exception("SSL over HTTP proxy is not yet supported, but proxychains or similar would fix this ;-)")
         parts = urlparse(proxy)
         if not parts.scheme or not parts.netloc:
             raise Exception("Invalid proxy specified, scheme required")
@@ -453,6 +451,8 @@ class waftoolsengine:
 
                 return Socks5Proxy(netloc[0], int(netloc[1]))
             elif parts.scheme == "http":
+                if ssl:
+                    raise Exception("SSL over HTTP proxy is not yet supported, but proxychains or similar would fix this ;-)")
                 return HttpProxy(netloc[0], int(netloc[1]))
             else:
                 raise Exception("Unsupported proxy scheme")


### PR DESCRIPTION
Fix for #28 broke socks5 proxy support.