### PR TITLE
Check responses in better-wp-security to avoid NoneType exception

### DIFF
--- a/wafw00f/plugins/betterwpsecurity.py
+++ b/wafw00f/plugins/betterwpsecurity.py
@@ -10,7 +10,7 @@ def is_waf(self):
     if r is None:
         return False
 
-    r = normalresponse, _
+    normalresponse, _ = r
 
     link_header = normalresponse.getheader('Link') or ""
 

--- a/wafw00f/plugins/betterwpsecurity.py
+++ b/wafw00f/plugins/betterwpsecurity.py
@@ -5,7 +5,13 @@ NAME = 'Better WP Security'
 
 
 def is_waf(self):
-    normalresponse, _ = self.normalrequest()
+    r = self.normalrequest()
+
+    if r is None:
+        return False
+
+    r = normalresponse, _
+
     link_header = normalresponse.getheader('Link') or ""
 
     if "https://api.w.org/" not in link_header:
@@ -14,7 +20,7 @@ def is_waf(self):
 
     r = self.request("GET", self.path + "wp-content/plugins/better-wp-security/")
 
-    if not r:
+    if r is None:
         return False
 
     pluginresponse, _ = r

--- a/wafw00f/plugins/ibm.py
+++ b/wafw00f/plugins/ibm.py
@@ -5,8 +5,7 @@ NAME = 'IBM Web Application Security'
 
 
 def is_waf(self):
-    detected = False
-    r = self.protectedfolder()
-    if r is None:
-        detected = True
-    return detected
+    normal = self.normalrequest()
+    protected = self.protectedfolder()
+
+    return protected is None and normal is not None


### PR DESCRIPTION
All plugins were reviewed. This one (mine) was the only one with the issue.

Additionally, check the normal response in IBM plugin as it yields false
positives when the site does not respond. The reason came clear upon review.