### PR TITLE
Update install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     scripts=['wafw00f/bin/wafw00f'],
     install_requires=[
         'beautifulsoup4==4.6.0',
-        'pluginbase==0.3',
+        'pluginbase==0.7',
+        'html5lib==1.0.1'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -28,6 +29,7 @@ setup(
         'Topic :: System :: Networking :: Firewalls',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
     keywords='waf firewall detector fingerprint',
     extras_require={


### PR DESCRIPTION
`html5lib` was missing which led to the following traceback:

```bash
$ wafw00f https://217.7.66.65
Traceback (most recent call last):
  File "/home/test/.local/bin/wafw00f", line 4, in <module>
    from wafw00f import main
  File "/home/test/.local/lib/python3.6/site-packages/wafw00f/main.py", line 53, in <module>
    from wafw00f.lib.evillib import oururlparse, scrambledheader, waftoolsengine
  File "/home/test/.local/lib/python3.6/site-packages/wafw00f/lib/evillib.py", line 14, in <module>
    from bs4 import BeautifulSoup
  File "/home/test/.local/lib/python3.6/site-packages/bs4/__init__.py", line 30, in <module>
    from .builder import builder_registry, ParserRejectedMarkup
  File "/home/test/.local/lib/python3.6/site-packages/bs4/builder/__init__.py", line 314, in <module>
    from . import _html5lib
  File "/home/test/.local/lib/python3.6/site-packages/bs4/builder/_html5lib.py", line 70, in <module>
    class TreeBuilderForHtml5lib(html5lib.treebuilders._base.TreeBuilder):
AttributeError: module 'html5lib.treebuilders' has no attribute '_base'
```

Test run with the new requirements:

```bash
$ python3 setup.py test
[...]
Ran 5 tests in 0.262s

OK
```

Would be nice to get a new release as I still have a an open review request to include it into the Fedora Package Collection.

Related to #37.