### PR TITLE
Remove release pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-
 from setuptools import setup, find_packages
 
 
@@ -9,16 +8,16 @@ setup(
     version=__import__('wafw00f').__version__,
     description=('WAFW00F identifies and fingerprints '
                  'Web Application Firewall (WAF) products.'),
-    author='sandrogauci',
+    author='Sandro Gauci',
     author_email='sandro@enablesecurity.com',
     license='BSD License',
     url='https://github.com/sandrogauci/wafw00f',
     packages=find_packages(),
     scripts=['wafw00f/bin/wafw00f'],
     install_requires=[
-        'beautifulsoup4==4.6.0',
-        'pluginbase==0.7',
-        'html5lib==1.0.1'
+        'beautifulsoup4',
+        'pluginbase',
+        'html5lib'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -34,17 +33,17 @@ setup(
     keywords='waf firewall detector fingerprint',
     extras_require={
         'dev': [
-            'prospector==0.10.1',
+            'prospector',
         ],
         'test': [
-            'httpretty==0.8.10',
-            'coverage==3.7.1',
-            'coveralls==0.5',
-            'python-coveralls==2.5.0',
-            'nose==1.3.6',
+            'httpretty',
+            'coverage',
+            'coveralls',
+            'python-coveralls',
+            'nose',
         ],
         'docs': [
-            'Sphinx==1.3.1',
+            'Sphinx',
         ],
     },
     test_suite='nose.collector',


### PR DESCRIPTION
Remove the pinning of dependencies to make `wafw00f` installable beside other tools, e.g., in a `venv`. This is also required if the tool is shipped as package (e.g., [Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=1704958) already has later releases of the dependencies as package available).