### PR TITLE
New header fingerprint + Fixing fingerprint for XLabs WAF

### DIFF
--- a/wafw00f/plugins/xlabssecuritywaf.py
+++ b/wafw00f/plugins/xlabssecuritywaf.py
@@ -5,8 +5,12 @@ NAME = 'XLabs Security WAF (XLabs)'
 def is_waf(self):
     if self.matchheader(('x-cdn', 'XLabs Security')):
         return True
-    # Another nice fingerprint found where server returns a
+    # This is another fingerprint header found in a different site
+    # during extensive testing for this plugin.
+    if self.matchheader(('Secured', r'^By XLabs Security.+?')):
+        return True
+    # Another nice fingerprint found where server returns attack
     # header as 'Server: XLabs WAF v3.0 http://www.xlabs.com.br/waf'
-    if self.matchheader(('server', r'XLabs WAF(.*)?')):
+    if self.matchheader(('Server', r'^XLabs WAF.+?'), attack=True):
         return True
     return False


### PR DESCRIPTION
During testing of the XLabs Security plugin on 3 sites, I found another header fingerprint which is quite reliable in fingerprinting XLabs WAF.
```
Secured: By XLabs Security www.xlabs.com.br
Server: Apache
Strict-Transport-Security: max-age=63072000; preload
Vary: Accept-Encoding
x-cdn: XLabs Security
X-CDN-Request-ID: XOADaH8AAAEAAGqzWK8AAAAW
X-UA-Compatible: IE=Edge,chrome=1
```
 Also I noticed that the existing `Server` based fingerprint is reproduced only during attack conditions. 
```
Connection: Keep-Alive
Content-Length: 241
Content-Type: text/html; charset=iso-8859-1
Date: Sat, 18 May 2019 13:14:49 GMT
Keep-Alive: timeout=5, max=100
Public-Key-Pins: pin-sha256="4U/WhYNLrhkKLLrXPtJOAPEXFhzqq8YGNbQAy50Vy74="; pin-sha256="HxT9JlwH08GBgejrE3cqgoT6MdFvjeSalyXv2+sFnbg="; max-age=300
Server: XLabs WAF v3.0
Strict-Transport-Security: max-age=63072000; preload
```
This pull request fixes the above issues.