### PR TITLE
Fix error in Request ID regex

### DIFF
--- a/wafw00f/plugins/ptaf.py
+++ b/wafw00f/plugins/ptaf.py
@@ -10,7 +10,7 @@ NAME = 'PT Application Firewall (Positive Technologies)'
 def is_waf(self):
     schemes = [
         self.matchContent(r'<h1.{0,10}?Forbidden'),
-        self.matchContent(r'<pre>Request.ID:.{0,10}?\d{4}\-(\d{2})+.{0,15}?pre>')
+        self.matchContent(r'<pre>Request.ID:.{0,10}?\d{4}\-(\d{2})+.{0,35}?pre>')
     ]
     if all(i for i in schemes):
         return True


### PR DESCRIPTION
Fix error in Request ID regex that breaks correct WAF identification.
Changed 15 to 35, because 15 symbols between date and 'pre>' are not enough for this signature.

Sample of WAF block response:
```
<h1>Forbidden</h1><pre>Request ID: 2017-07-31-13-59-56-72BCA33A11EC3784</pre>
```

#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [x] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [x] v2.x
- Operating System:
    - [x] Linux Debian
    - [ ] Windows
    - [ ] MacOS

#### Does this close any currently open issues? 
[Mention any issue which this PR closes]

#### Does this add any new dependency?
[Mention if this PR includes any new library]

#### Does this add any new command line switch/argument?
[Mention if the changes add any new arguments like `--arg`]

#### Any other comments you would like to make?
[Anything more you'd want the reviewer to know]
