### PR TITLE
Add custom headers (except for user agent) for generic detection

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -76,11 +76,6 @@ class WAFW00F(waftoolsengine):
     attcom = [xssAttack, sqliAttack, lfiAttack]
     attacks = [xssAttack, xxeAttack, lfiAttack, sqliAttack, oscAttack]
 
-    def merge_two_dicts(self, first, second):
-        result = first.copy()
-        result.update(second)
-        return result
-
     def genericdetect(self):
         reason = ''
         reasons = ['Blocking is being done at connection/packet level.',
@@ -94,7 +89,7 @@ class WAFW00F(waftoolsengine):
             resp1 = self.performCheck(self.normalRequest)
             if 'User-Agent' in self.headers:
                 del self.headers['User-Agent']  # Deleting the user-agent key from object not dict.
-            resp3 = self.customRequest(headers=self.merge_two_dicts(def_headers, self.headers))
+            resp3 = self.customRequest(headers=self.headers)
             if resp1.status_code != resp3.status_code:
                 self.log.info('Server returned a different response when request didn\'t contain the User-Agent header.')
                 reason = reasons[4]

--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -76,6 +76,11 @@ class WAFW00F(waftoolsengine):
     attcom = [xssAttack, sqliAttack, lfiAttack]
     attacks = [xssAttack, xxeAttack, lfiAttack, sqliAttack, oscAttack]
 
+    def merge_two_dicts(self, first, second):
+        result = first.copy()
+        result.update(second)
+        return result
+
     def genericdetect(self):
         reason = ''
         reasons = ['Blocking is being done at connection/packet level.',
@@ -89,7 +94,7 @@ class WAFW00F(waftoolsengine):
             resp1 = self.performCheck(self.normalRequest)
             if 'User-Agent' in self.headers:
                 del self.headers['User-Agent']  # Deleting the user-agent key from object not dict.
-            resp3 = self.customRequest(headers=def_headers)
+            resp3 = self.customRequest(headers=self.merge_two_dicts(def_headers, self.headers))
             if resp1.status_code != resp3.status_code:
                 self.log.info('Server returned a different response when request didn\'t contain the User-Agent header.')
                 reason = reasons[4]


### PR DESCRIPTION
This is needed for HTTP Basic Authentication for example, which will get detected as a generic WAF otherwise.
Before this commit the “normal” requests were made with the `Authorization` header intact, whereas the generic request would remove the `Authorization` header and result in a 403 Forbidden.

#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [X] A new feature/enhancement.
- [X] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [X] v3.x
    - [ ] v2.x
- Operating System:
    - [X] Kali Linux
    - [ ] Windows
    - [ ] MacOS

#### Does this close any currently open issues? 
No, I just noticed it myself.

#### Does this add any new dependency?
No.

#### Does this add any new command line switch/argument?
No.

#### Any other comments you would like to make?
There is a quicker way to merge the dictionaries, but it is for Python 3.5 and above, so I hope this is okay.
