### PR TITLE
remove global rq

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -23,6 +23,7 @@ from wafw00f.manager import load_plugins
 from wafw00f.wafprio import wafdetectionsprio
 from wafw00f.lib.evillib import urlParser, waftoolsengine, def_headers
 
+
 class WAFW00F(waftoolsengine):
 
     xsstring = '<script>alert("XSS");</script>'
@@ -38,6 +39,7 @@ class WAFW00F(waftoolsengine):
         self.attackres = None
         waftoolsengine.__init__(self, target, debuglevel, path, proxies, followredirect, extraheaders)
         self.knowledge = dict(generic=dict(found=False, reason=''), wafname=list())
+        self.rq = self.normalRequest()
 
     def normalRequest(self):
         return self.Request()
@@ -164,9 +166,11 @@ class WAFW00F(waftoolsengine):
     def matchHeader(self, headermatch, attack=False):
         if attack:
             r = self.attackres
-        else: r = rq
+        else:
+            r = self.rq
         if r is None:
             return
+
         header, match = headermatch
         headerval = r.headers.get(header)
         if headerval:
@@ -184,7 +188,8 @@ class WAFW00F(waftoolsengine):
     def matchStatus(self, statuscode, attack=True):
         if attack:
             r = self.attackres
-        else: r = rq
+        else:
+            r = self.rq
         if r is None:
             return
         if r.status_code == statuscode:
@@ -197,7 +202,8 @@ class WAFW00F(waftoolsengine):
     def matchReason(self, reasoncode, attack=True):
         if attack:
             r = self.attackres
-        else: r = rq
+        else:
+            r = self.rq
         if r is None:
             return
         # We may need to match multiline context in response body
@@ -208,7 +214,8 @@ class WAFW00F(waftoolsengine):
     def matchContent(self, regex, attack=True):
         if attack:
             r = self.attackres
-        else: r = rq
+        else:
+            r = self.rq
         if r is None:
             return
         # We may need to match multiline context in response body
@@ -338,7 +345,7 @@ def main():
     print(randomArt())
     if options.list:
         print('[+] Can test for these WAFs:\r\n')
-        attacker = WAFW00F(None)
+        WAFW00F(None)
         try:
             m = [i.replace(')', '').split(' (') for i in wafdetectionsprio]
             print(R+'  WAF Name'+' '*24+'Manufacturer\n  '+'-'*8+' '*24+'-'*12+'\n')
@@ -418,9 +425,7 @@ def main():
         attacker = WAFW00F(target, debuglevel=options.verbose, path=path,
                     followredirect=options.followredirect, extraheaders=extraheaders,
                         proxies=proxies)
-        global rq
-        rq = attacker.normalRequest()
-        if rq is None:
+        if attacker.rq is None:
             log.error('Site %s appears to be down' % hostname)
             continue
         if options.test:


### PR DESCRIPTION
#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [x] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [x] v2.x
- Operating System:
    - [x] Linux (Please specify distro)
    - [x] Windows
    - [x] MacOS

I think global rq is not a good practice. And it blocks to use WAFW00F as a library. This way we can use as a library.

For example;

```python
  from wafw00f.main import WAFW00F

  attacker = WAFW00F(target="http://example.com")
  waf = attacker.identwaf()
```
