### PR TITLE
Detect Rhode & Schwarz Cloud Protector

### DIFF
--- a/wafw00f/plugins/cloudprotector.py
+++ b/wafw00f/plugins/cloudprotector.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+'''
+Copyright (C) 2020, WAFW00F Developers.
+See the LICENSE file for copying permission.
+'''
+
+NAME = 'Cloud Protector (Rohde & Schwarz CyberSecurity)'
+
+def is_waf(self):
+    schemes = [
+        self.matchContent(r'Cloud Protector.*by Rohde &amp; Schwarz Cybersecurity')
+    ]
+    if any(i for i in schemes):
+        return True
+    return False

--- a/wafw00f/wafprio.py
+++ b/wafw00f/wafprio.py
@@ -50,6 +50,7 @@ wafdetectionsprio = [
     'Cloudfront (Amazon)',
     'CrawlProtect (Jean-Denis Brun)',
     'DataPower (IBM)',
+    'Cloud Protector (Rohde & Schwarz CyberSecurity)',
     'DenyALL (Rohde & Schwarz CyberSecurity)',
     'Distil (Distil Networks)',
     'DOSarrest (DOSarrest Internet Security)',


### PR DESCRIPTION
This SaaS WAF is the official cloud protection by Rhode & Schwarz,
it probably use a "DenyALL" engine, so i set a priority just before
'DenyALL (Rohde & Schwarz CyberSecurity)',

#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [x] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [ ] Linux (Please specify distro)
    - [ ] Windows
    - [x] MacOS