### PR TITLE
Remove unnecessary WAFWOOF object initialisation when listing WAFs

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -347,7 +347,6 @@ def main():
     print(randomArt())
     if options.list:
         print('[+] Can test for these WAFs:\r\n')
-        WAFW00F(None)
         try:
             m = [i.replace(')', '').split(' (') for i in wafdetectionsprio]
             print(R+'  WAF Name'+' '*24+'Manufacturer\n  '+'-'*8+' '*24+'-'*12+'\n')


### PR DESCRIPTION
`attacker = WafW00F(None)` used to be necessary when `main.py` was first created:

https://github.com/EnableSecurity/wafw00f/blob/1275ba1f36135bc8abdcfa857f5bca39ff1d987d/wafw00f/main.py#L778-L782

`attacker = WafW00F(None)` was later changed to `WafW00F(None)` in d6cf82826244d93d30f3c9ce1aa3c758f6e1a322.

https://github.com/EnableSecurity/wafw00f/blob/d6cf82826244d93d30f3c9ce1aa3c758f6e1a322/wafw00f/main.py#L348-L350

As best I can tell this line is unnecessary.

This line causes issues when wafw00f is piped to another tool.

# Before

Note the invalid URL error.

```
$ wafw00f -l | head -n 30
ERROR:wafw00f:Something went wrong Invalid URL 'None': No schema supplied. Perhaps you meant http://None?

                   ______
                  /      \
                 (  Woof! )
                  \  ____/                      )
                  ,,                           ) (_
             .-. -    _______                 ( |__|
            ()``; |==|_______)                .)|__|
            / ('        /|\                  (  |__|
        (  /  )        / | \                  . |__|
         \(_)_))      /  |  \                   |__|

                    ~ WAFW00F : v2.1.0 ~
    The Web Application Firewall Fingerprinting Toolkit
    
[+] Can test for these WAFs:

  WAF Name                        Manufacturer
  --------                        ------------

  ACE XML Gateway                  Cisco                            
  aeSecure                         aeSecure                         
  AireeCDN                         Airee                            
  Airlock                          Phion/Ergon                      
  Alert Logic                      Alert Logic                      
  AliYunDun                        Alibaba Cloud Computing          
  Anquanbao                        Anquanbao                        
  AnYu                             AnYu Technologies                
  Approach                         Approach                         
  AppWall                          Radware                          
```

# After

```
$ wafw00f -l | head -n 30

                   ______
                  /      \
                 (  Woof! )
                  \  ____/                      )
                  ,,                           ) (_
             .-. -    _______                 ( |__|
            ()``; |==|_______)                .)|__|
            / ('        /|\                  (  |__|
        (  /  )        / | \                  . |__|
         \(_)_))      /  |  \                   |__|

                    ~ WAFW00F : v2.1.0 ~
    The Web Application Firewall Fingerprinting Toolkit
    
[+] Can test for these WAFs:

  WAF Name                        Manufacturer
  --------                        ------------

  ACE XML Gateway                  Cisco                            
  aeSecure                         aeSecure                         
  AireeCDN                         Airee                            
  Airlock                          Phion/Ergon                      
  Alert Logic                      Alert Logic                      
  AliYunDun                        Alibaba Cloud Computing          
  Anquanbao                        Anquanbao                        
  AnYu                             AnYu Technologies                
  Approach                         Approach                         
  AppWall                          Radware                          
```
