### PR TITLE
update f5bigipasm detect pattern

### DIFF
--- a/wafw00f/plugins/f5bigipasm.py
+++ b/wafw00f/plugins/f5bigipasm.py
@@ -8,10 +8,17 @@ NAME = 'BIG-IP AppSec Manager (F5 Networks)'
 
 
 def is_waf(self):
-    schemes = [
+    schema1 = [
         self.matchContent('the requested url was rejected'),
         self.matchContent('please consult with your administrator')
     ]
-    if all(i for i in schemes):
+
+    schema2 = [
+        self.matchCookie(r'^TS.+?')
+    ]
+
+    if all(i for i in schema1):
+        return True
+    if all(i for i in schema2):
         return True
     return False


### PR DESCRIPTION
Some people use custom page on BIG-IP ASM, then the original schemes will not compare.
BIG-IP ASM system sets cookies begin with TS, the number of subsequent digits varies with the version, so I append the schema2 pattern.

ref:  https://support.f5.com/csp/article/K6850#main

#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [x] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [ ] Linux (Please specify distro)
    - [x] Windows
    - [ ] MacOS

#### Does this close any currently open issues? 
[Mention any issue which this PR closes]
NO
#### Does this add any new dependency?
[Mention if this PR includes any new library]
NO
#### Does this add any new command line switch/argument?
[Mention if the changes add any new arguments like `--arg`]
NO
#### Any other comments you would like to make?
[Anything more you'd want the reviewer to know]
NO