### PR TITLE
Added an option to disable colors from output. 

### DIFF
--- a/wafw00f/lib/asciiarts.py
+++ b/wafw00f/lib/asciiarts.py
@@ -4,25 +4,56 @@ Copyright (C) 2022, WAFW00F Developers.
 See the LICENSE file for copying permission.
 '''
 
-from sys import platform
+from dataclasses import asdict, dataclass, fields
 from random import randint
+
 from wafw00f import __version__
 
-# Colors for terminal
-W = '\033[1;97m'
-Y = '\033[1;93m'
-G = '\033[1;92m'
-R = '\033[1;91m'
-B = '\033[1;94m'
-C = '\033[1;96m'
-E = '\033[0m'
 
-# Windows based systems do not support ANSI sequences,
-# hence not displaying them.
-if 'win' in platform:
-    W = Y = G = R = B = C = E = ''
+@dataclass
+class Color:
+    """ANSI colors."""
+    W: str = '\033[1;97m'
+    Y: str = '\033[1;93m'
+    G: str = '\033[1;92m'
+    R: str = '\033[1;91m'
+    B: str = '\033[1;94m'
+    C: str = '\033[1;96m'
+    E: str = '\033[0m'
+
+    @classmethod
+    def disable(cls):
+        """Disables all colors."""
+        cls.W = ''
+        cls.Y = ''
+        cls.G = ''
+        cls.R = ''
+        cls.B = ''
+        cls.C = ''
+        cls.E = ''
+
+    @classmethod
+    def unpack(cls):
+        """Unpacks and returns the color values.
+        Useful for brevity, e.g.:
+        (W,Y,G,R,B,C,E) = Color.unpack()
+        """
+        return (cls.W, 
+                cls.Y,
+                cls.G,
+                cls.R,
+                cls.B,
+                cls.C,
+                cls.E
+                )
+          
+
+
 
 def randomArt():
+    # Colors for terminal
+
+    (W,Y,G,R,B,C,E) = Color.unpack()
 
     woof = '''
                    '''+W+'''______

--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -17,11 +17,12 @@ import re
 import sys
 from collections import defaultdict
 from optparse import OptionParser
-from wafw00f.lib.asciiarts import *
-from wafw00f import __version__, __license__
+
+from wafw00f import __license__, __version__
+from wafw00f.lib.asciiarts import Color, randomArt
+from wafw00f.lib.evillib import def_headers, urlParser, waftoolsengine
 from wafw00f.manager import load_plugins
 from wafw00f.wafprio import wafdetectionsprio
-from wafw00f.lib.evillib import urlParser, waftoolsengine, def_headers
 
 
 class WAFW00F(waftoolsengine):
@@ -340,12 +341,24 @@ def main():
                       default=False, help='Print out the current version of WafW00f and exit.')
     parser.add_option('--headers', '-H', dest='headers', action='store', default=None,
                       help='Pass custom headers via a text file to overwrite the default header set.')
+    parser.add_option('--no-colors', '-C', dest='colors', action='store_false', 
+                      default=True, help='Disable ANSI colors in output.')
+    
     options, args = parser.parse_args()
+    
     logging.basicConfig(level=calclogginglevel(options.verbose))
     log = logging.getLogger('wafw00f')
     if options.output == '-':
         disableStdOut()
+
+    # Windows based systems do not support ANSI sequences,
+    # hence not displaying them.
+    if not options.colors or 'win' in sys.platform:
+        Color.disable()
+        
     print(randomArt())
+    (W,Y,G,R,B,C,E) = Color.unpack()
+    
     if options.list:
         print('[+] Can test for these WAFs:\r\n')
         try:

--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -341,7 +341,7 @@ def main():
                       default=False, help='Print out the current version of WafW00f and exit.')
     parser.add_option('--headers', '-H', dest='headers', action='store', default=None,
                       help='Pass custom headers via a text file to overwrite the default header set.')
-    parser.add_option('--no-colors', '-C', dest='colors', action='store_false', 
+    parser.add_option('--no-colors', dest='colors', action='store_false', 
                       default=True, help='Disable ANSI colors in output.')
     
     options, args = parser.parse_args()


### PR DESCRIPTION
ANSI colors in the output interfere with the automatic processing of results. I've added a CLI option to disable colors (`--no-colors`).

This required me to also make changes to how the ANSI colors are stored. They were originally directly imported from `asciiarts.py`, but this makes controlling these values more difficult. I've therefore added a `Color` dataclass and added a `disable()` classmethod. In order to preserve the rest of the functionality, and maintain the brevity of using single letters for colors, I've added an `unpack()` function that can be used to declare colors where needed locally.

#### Which category is this pull request?
- [x] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [x] Linux
    - [x] Windows
    - [x] MacOS

#### Does this close any currently open issues? 
No.

#### Does this add any new dependency?
No.

#### Does this add any new command line switch/argument?
Yes, this PR includes the `--no-colors` or `-C` CLI argument.

#### Any other comments you would like to make?
Thank you for developing `wafw00f`. I use it frequently during security assessments.
