### PR TITLE
adding Envoy Reverse proxy to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ $ wafw00f -l
   YXLink                           YxLink Technologies
   Zenedge                          Zenedge
   ZScaler                          Accenture
+  Envoy                            EnvoyProxy
 ```
 
 ## How do I use it?

--- a/wafw00f/plugins/envoy.py
+++ b/wafw00f/plugins/envoy.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+'''
+Copyright (C) 2022, WAFW00F Developers.
+See the LICENSE file for copying permission.
+'''
+
+NAME = 'Envoy'
+
+
+def is_waf(self):
+    if self.matchHeader(('server', 'envoy')):
+        return True
+
+    return False

--- a/wafw00f/plugins/envoy.py
+++ b/wafw00f/plugins/envoy.py
@@ -11,4 +11,31 @@ def is_waf(self):
     if self.matchHeader(('server', 'envoy')):
         return True
 
+    if self.matchHeader(('x-envoy-upstream-service-time', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-downstream-service-cluster', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-downstream-service-node', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-external-address', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-force-trace', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-internal', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-original-dst-host', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-original-path', '.+')):
+        return True
+
+    if self.matchHeader(('x-envoy-local-overloaded', '.+')):
+        return True
+
     return False

--- a/wafw00f/plugins/envoy.py
+++ b/wafw00f/plugins/envoy.py
@@ -4,7 +4,7 @@ Copyright (C) 2022, WAFW00F Developers.
 See the LICENSE file for copying permission.
 '''
 
-NAME = 'Envoy'
+NAME = 'Envoy (EnvoyProxy)'
 
 
 def is_waf(self):

--- a/wafw00f/wafprio.py
+++ b/wafw00f/wafprio.py
@@ -59,6 +59,7 @@ wafdetectionsprio = [
     'DynamicWeb Injection Check (DynamicWeb)',
     'Edgecast (Verizon Digital Media)',
     'Eisoo Cloud Firewall (Eisoo)',
+    'Envoy (EnvoyProxy)',
     'Expression Engine (EllisLab)',
     'BIG-IP AppSec Manager (F5 Networks)',
     'BIG-IP AP Manager (F5 Networks)',


### PR DESCRIPTION
#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [x] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [x] Linux (Please specify distro)
    - [ ] Windows
    - [ ] MacOS

#### Does this close any currently open issues? 
No

#### Does this add any new dependency?
No

#### Does this add any new command line switch/argument?
No

#### Any other comments you would like to make?
I've added the plugin but I have just seen the header server envoy, so I would improve that because my first scan doesn't seem to detect it...

I've followed the documentation here : https://github.com/EnableSecurity/wafw00f/wiki/Writing-New-WAF-Checks
