### PR TITLE
Freeze docker python version to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.8-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN python setup.py install


### PR DESCRIPTION
#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [x] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [x] Linux (Please specify distro)
    - [ ] Windows
    - [ ] MacOS

#### Does this close any currently open issues? 
Closes [211](https://github.com/EnableSecurity/wafw00f/issues/211)

#### Does this add any new dependency?
No

#### Does this add any new command line switch/argument?
No

#### Any other comments you would like to make?
Just fixed python version in Dockerfile
