### PR TITLE
setup.py installs wafw00f binary twice

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Source Code": "https://github.com/EnableSecurity/wafw00f/tree/master"
     },
     packages=find_packages(),
-    scripts=['wafw00f/bin/wafw00f'],
     install_requires=[
         'requests',
         'requests[socks]',


### PR DESCRIPTION
"scripts" is an old way of doing it, entry_points is the way to go. See:
https://stackoverflow.com/questions/18787036/difference-between-entry-points-console-scripts-and-scripts-in-setup-py

This pull request fixes the following error:
```
python3.12 -m gpep517 install-wheel --destdir=/var/tmp/portage/net-analyzer/wafw00f-2.3.0/work/wafw00f-2.3.0-python3_12/install --interpreter=/usr/bin/python3.12 --prefix=/usr --optimize=all /var/tmp/portage/net-analyzer/wafw00f-2.3.0/work/wafw00f-2.3.0-python3_12/wheel/wafw00f-2.3.0-py3-none-any.whl
2024-12-24 09:18:06,380 gpep517 INFO Installing /var/tmp/portage/net-analyzer/wafw00f-2.3.0/work/wafw00f-2.3.0-python3_12/wheel/wafw00f-2.3.0-py3-none-any.whl into /var/tmp/portage/net-analyzer/wafw00f-2.3.0/work/wafw00f-2.3.0-python3_12/install
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.12/site-packages/gpep517/__main__.py", line 443, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/gpep517/__main__.py", line 439, in main
    return func(args)
           ^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gpep517/__main__.py", line 272, in install_wheel
    install_wheel_impl(args, args.wheel)
  File "/usr/lib/python3.12/site-packages/gpep517/__main__.py", line 267, in install_wheel_impl
    install(source, dest, {})
  File "/usr/lib/python3.12/site-packages/installer/_core.py", line 109, in install
    record = destination.write_file(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/installer/destinations.py", line 203, in write_file
    return self.write_to_fs(
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/installer/destinations.py", line 167, in write_to_fs
    raise FileExistsError(message)
FileExistsError: File already exists: /var/tmp/portage/net-analyzer/wafw00f-2.3.0/work/wafw00f-2.3.0-python3_12/install/usr/bin/wafw00f

```
