### PR TITLE
More specific cookie matching for F5 ASM

### DIFF
--- a/wafw00f/plugins/f5bigipasm.py
+++ b/wafw00f/plugins/f5bigipasm.py
@@ -11,7 +11,12 @@ def is_waf(self):
     if check_schema_01(self):
         return True
 
-    if self.matchCookie(r'^TS.+?'):
+    # ASM ≥ 11.4.0 → eight hex digits after “TS” - https://my.f5.com/manage/s/article/K6850
+    if self.matchCookie((r'^TS[a-fA-F0-9]{8}$', r'.+')):
+        return True
+    
+    # ASM 10.0.0 – 11.3.0 → six hex digits after “TS” - https://my.f5.com/manage/s/article/K6850
+    if self.matchCookie((r'^TS[a-fA-F0-9]{6}$', r'.+')):
         return True
 
     return False


### PR DESCRIPTION
#### Which category is this pull request?
<!-- Check the boxes with 'x' like '[x]' -->
- [ ] A new feature/enhancement.
- [ ] Fix an issue/feature-request.
- [x] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
<!-- Check the boxes with 'x' like '[x]' -->
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [ ] Linux (Please specify distro)
    - [ ] Windows
    - [x] MacOS

#### Does this close any currently open issues? 
No

#### Does this add any new dependency?
No

#### Does this add any new command line switch/argument?
No

#### Any other comments you would like to make?
This improves the cookie matching on F5 ASM. As stated in their [knowledge base](https://my.f5.com/manage/s/article/K6850#main), the structure of their cookies does not only begin with `TS` it also has specifically 6 or 8 hex decimal characters that follow. The improvement matches the cookie keys more specifically.
