### PR TITLE
Fixed type missmatch introduced in PR 229

### DIFF
--- a/wafw00f/plugins/f5bigipasm.py
+++ b/wafw00f/plugins/f5bigipasm.py
@@ -12,11 +12,11 @@ def is_waf(self):
         return True
 
     # ASM ≥ 11.4.0 → eight hex digits after “TS” - https://my.f5.com/manage/s/article/K6850
-    if self.matchCookie((r'^TS[a-fA-F0-9]{8}$', r'.+')):
+    if self.matchCookie(r'TS[a-fA-F0-9]{8}=.+'):
         return True
     
     # ASM 10.0.0 – 11.3.0 → six hex digits after “TS” - https://my.f5.com/manage/s/article/K6850
-    if self.matchCookie((r'^TS[a-fA-F0-9]{6}$', r'.+')):
+    if self.matchCookie(r'TS[a-fA-F0-9]{6}=.+'):
         return True
 
     return False


### PR DESCRIPTION
The improvement for the module `f5bigipasm.py` introduced in https://github.com/EnableSecurity/wafw00f/pull/229 broke its functionality:

```
Traceback (most recent call last):
  File "/usr/local/bin/wafw00f", line 33, in <module>
    sys.exit(load_entry_point('wafw00f==2.3.1', 'console_scripts', 'wafw00f')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wafw00f-2.3.1-py3.11.egg/wafw00f/main.py", line 502, in main
    waf, xurl = attacker.identwaf(options.findall)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wafw00f-2.3.1-py3.11.egg/wafw00f/main.py", line 285, in identwaf
    if self.wafdetections[wafvendor](self):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wafw00f-2.3.1-py3.11.egg/wafw00f/plugins/f5bigipasm.py", line 15, in is_waf
    if self.matchCookie((r'^TS[a-fA-F0-9]{8}$', r'.+')):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wafw00f-2.3.1-py3.11.egg/wafw00f/main.py", line 241, in matchCookie
    return self.matchHeader(('Set-Cookie', match), attack=attack)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wafw00f-2.3.1-py3.11.egg/wafw00f/main.py", line 225, in matchHeader
    if re.search(match, headerval, re.I):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 176, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 286, in _compile
    raise TypeError("first argument must be string or compiled pattern")
TypeError: first argument must be string or compiled pattern
``` 

The newly extended regex results in a data type mismatch because the function `re.search()` now receives a tuple instead of a string resulting in above error. The change is this PR should solve this issue by reducing the regex back to a single string again.

#### Which category is this pull request?
- [ ] A new feature/enhancement.
- [X] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
- Python Version
    - [X] v3.x
    - [ ] v2.x
- Operating System:
    - [ ] Linux (Please specify distro)
    - [ ] Windows
    - [X] MacOS (through Docker)

#### Does this close any currently open issues? 
No, its a patch for https://github.com/EnableSecurity/wafw00f/pull/229

#### Does this add any new dependency?
No

#### Does this add any new command line switch/argument?
No

#### Any other comments you would like to make?
No
