### PR TITLE
Fix FortiGuard detection logic (False Negative)

### DIFF
--- a/wafw00f/plugins/fortiguard.py
+++ b/wafw00f/plugins/fortiguard.py
@@ -13,16 +13,12 @@ def is_waf(self):
     return False
 
 def check_schema(self):
+    # Use OR logic with strong signatures containing explicit FortiGuard/Fortinet branding
+    # Generic "Web Filter" strings are avoided to prevent false positives
     if self.matchContent('FortiGuard Intrusion Prevention'):
         return True
 
     if self.matchContent('//globalurl.fortinet.net'):
-        return True
-
-    if self.matchContent('<title>Web Filter Violation'):
-        return True
-    
-    if self.matchContent('Web Filter Block Override'):
         return True
 
     return False


### PR DESCRIPTION
Currently, the FortiGuard plugin uses strict dependency logic (AND), requiring the content body, the 'globalurl' link, AND the specific <title> tag to all be present to confirm detection.

I encountered a live target that displays the standard "FortiGuard Intrusion Prevention" block page but was returning False because it lacks the specific <title> tag and the 'globalurl' link used in the existing check.

**Changes:**
- Updated `check_schema` to use OR logic. If any of the strong unique signatures are found, it returns True.
- Added 'Web Filter Block Override' as an additional signature found on newer FortiOS block pages.

This fixes the false negative without introducing false positives, as the strings are specific to Fortinet products.