### PR TITLE
Fix Dockerfile: replace removed setup.py with pip install .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11.9-alpine
 WORKDIR /usr/src/app
 COPY . .
-RUN python setup.py install
+RUN pip install .
 ENTRYPOINT [ "wafw00f" ]


### PR DESCRIPTION
#### Which category is this pull request?
- [ ] A new feature/enhancement.
- [x] Fix an issue/feature-request.
- [ ] An improvement to existing modules.
- [ ] Other (Please mention below).

#### Where has this been tested?
- Python Version
    - [x] v3.x
    - [ ] v2.x
- Operating System:
    - [ ] Linux (Please specify distro)
    - [ ] Windows
    - [x] MacOS

#### Does this close any currently open issues?
No related open issue, but the Docker build described in the README is currently broken for everyone following the documented steps.

#### Does this add any new dependency?
No.

#### Does this add any new command line switch/argument?
No.

#### Any other comments you would like to make?
The project migrated to `pyproject.toml` and `setup.py` was removed, but the Dockerfile still runs `python setup.py install`. As a result, `docker build . -t wafw00f` fails with:
```
python: can't open file '/usr/src/app/setup.py': [Errno 2] No such file or directory
```

This PR replaces that line with `pip install .`, which works with the current `pyproject.toml`-based build. Tested locally on macOS (Docker via OrbStack, base image `python:3.11.9-alpine` unchanged) — build succeeds and `docker run --rm -it wafw00f -l` and `docker run --rm -it wafw00f https://example.com` both work as expected.